### PR TITLE
Enforce opengl 3.3

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -39,7 +39,7 @@ sys.path.append(dn(dn(abspath(__file__))))
 
 from pyglet.gl import GL_LINES, GL_FLOAT, GL_STATIC_DRAW, GL_UNSIGNED_SHORT
 from pyglet.gl import glDrawElements, glClearColor, Config, glGenVertexArrays, glDeleteVertexArrays, glBindVertexArray, GLuint, glViewport
-from pyglet.window import Window, mouse, get_platform   
+from pyglet.window import Window, mouse, get_platform , key 
 from pyglet import app
 
 import tinyblend as blend
@@ -149,6 +149,13 @@ class Game(Window):
             self.position[1] += dy * 0.005
 
         self.upload_uniforms()
+
+    def on_key_press(self, sym, mod):
+        if sym == key.ESCAPE:
+            del self.shader
+            del self.suzanne
+            glDeleteVertexArrays(1, self.vao)
+            self.close()
 
     def on_draw(self):
         # Clear the window

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -54,10 +54,7 @@ class Game(Window):
 
     def __init__(self):
         display = get_platform().get_default_display()
-        screen = display.get_default_screen()
-
-        template = Config(alpha_size=8)
-        config = screen.get_best_config(template)
+        config = display.get_default_screen().get_best_config(Config())
         config.major_version = 3
         config.minor_version = 3
         context = config.create_context(None)
@@ -114,6 +111,9 @@ class Game(Window):
         suzanne_indices.init(indices)
         self.suzanne = (suzanne, suzanne_indices, len(suzanne_indices)*2)
 
+        # Map the attribute and bind the buffer
+        suzanne.bind()
+        suzanne_indices.bind()
         self.shader.map_attributes(suzanne)
 
         # Set the background color
@@ -162,11 +162,7 @@ class Game(Window):
         self.clear()
 
         # Draw the mesh
-        suz, suz_indices, suz_len = self.suzanne
-        suz.bind()
-        suz_indices.bind()
-        
-        glDrawElements(GL_LINES, suz_len, GL_UNSIGNED_SHORT, 0)
+        glDrawElements(GL_LINES, self.suzanne[2], GL_UNSIGNED_SHORT, 0)
     
 def main():
     game = Game()

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -38,7 +38,7 @@ from os.path import dirname as dn, abspath
 sys.path.append(dn(dn(abspath(__file__))))
 
 from pyglet.gl import GL_LINES, GL_FLOAT, GL_STATIC_DRAW, GL_UNSIGNED_SHORT
-from pyglet.gl import glDrawElements, glClearColor, Config, glGenVertexArrays, glDeleteVertexArrays, glBindVertexArray, GLuint
+from pyglet.gl import glDrawElements, glClearColor, Config, glGenVertexArrays, glDeleteVertexArrays, glBindVertexArray, GLuint, glViewport
 from pyglet.window import Window, mouse, get_platform   
 from pyglet import app
 
@@ -133,7 +133,7 @@ class Game(Window):
         uni.proj = perspective(60.0, width/height, 0.1, 256.0)
 
     def on_resize(self, width, height):
-        #Window.on_resize(self, width, height)
+        glViewport(0,0, width, height)
         self.upload_uniforms()
 
     def on_mouse_scroll(self, x, y, scroll_x, scroll_y):


### PR DESCRIPTION
Enforce opengl 3.3. 

This will allow some new configuration to run the demo (such as my laptop).

Vertex Array object must be used explicitly .

Also move some commands out of the draw loop and put them in the scene initialization.

Note: The default window resize of pyglet crash because it uses a deprecated opengl function. glViewport must be called manually.
