### PR TITLE
feat: ability to override a way to obtain a file handle

### DIFF
--- a/tinyblend.py
+++ b/tinyblend.py
@@ -737,8 +737,12 @@ class BlenderFile(object):
     def _from_addresses(self, ptr_list):
         return [self._from_address(ptr) if ptr != 0 else None for ptr in ptr_list]
 
+    @staticmethod
+    def _get_file_handler(path):
+        return open(path, 'rb')
+
     def __init__(self, blend_file_name):
-        handle = open(blend_file_name, 'rb')
+        handle = self._get_file_handler(blend_file_name)
 
         header = BlenderFile._parse_header(handle.read(12))
         if header is None:


### PR DESCRIPTION
Hello! Thanks for the great library!

I tried to use it for reading meta-data from various Blender files and some of them are compressed. Thus, I want to provide different file handlers (such as gzip reader) for the `__init__`.  So just extracted `_get_file_handler` method which can be overridden in inherited classes.